### PR TITLE
CI: run actionlint

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -1,0 +1,23 @@
+name: Actionlint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_call:
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10 # If hit, something went wrong
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      # Taken from https://github.com/rhysd/actionlint/blob/v1.7.7/docs/usage.md#use-actionlint-on-github-actions
+      - name: Download actionlint
+        id: get_actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        shell: bash
+      - name: Check workflow files
+        run: ${{ steps.get_actionlint.outputs.executable }}
+        shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up GHC and Cabal
-        uses: haskell/actions/setup@v2
+        uses: haskell-actions/setup@v2
         id: setup
         with:
           # Version numbers as in the top-level README.md file too


### PR DESCRIPTION
## Context

1. To fix https://github.com/tweag/minimal-megaparsec-tutorial/issues/1, I want to augment the CI
2. Before augmenting the CI, I want to add a quality check to it

## How to trust this PR

* Look at actionlint's run on this PR
* You can try actionlint yourself
* [actionlint](https://github.com/rhysd/actionlint) is an established checker