### PR TITLE
Fix computeWidthAndHeight

### DIFF
--- a/src/Render.hs
+++ b/src/Render.hs
@@ -13,7 +13,7 @@ render elements = do
       putChar (fromMaybe ' ' symbol)
     putStrLn ""
   where
-    (width, height) = computeWidthAndHeight elements
+    (width, height) = maxXY elements
     widths = [0 .. width]
     heights = [0 .. height]
 
@@ -39,11 +39,10 @@ elementContains element (cx, cy) =
     Cell x y _ -> (x == cx) && (y == cy)
     Start x y -> (x == cx) && (y == cy)
 
--- | Compute the width and height of the map. This is the maximum
--- size of the x and y coordinates of all elements. Iterating over [0..w]
+-- | Compute the maximum coordinate of an element in the map. Iterating over [0..w]
 -- and [0..h] will cover all elements.
-computeWidthAndHeight :: [Element] -> (Int, Int)
-computeWidthAndHeight =
+maxXY :: [Element] -> (Int, Int)
+maxXY =
   foldl
     ( \(w, h) e ->
         let mw = maxX e; mh = maxY e

--- a/src/Render.hs
+++ b/src/Render.hs
@@ -14,8 +14,8 @@ render elements = do
     putStrLn ""
   where
     (width, height) = computeWidthAndHeight elements
-    widths = [0 .. width - 1]
-    heights = [0 .. height - 1]
+    widths = [0 .. width]
+    heights = [0 .. height]
 
 renderCell :: [Element] -> (Int, Int) -> Maybe Char
 renderCell elements cell =
@@ -45,13 +45,29 @@ elementContains element (cx, cy) =
 computeWidthAndHeight :: [Element] -> (Int, Int)
 computeWidthAndHeight =
   foldl
-    ( \(w, h) e -> case e of
-        HorizontalLine x _ l -> (max w (x + l), h)
-        VerticalLine _ y l -> (w, max h (y + l))
-        Cell x y _ -> (max w x, max h y)
-        Start x y -> (max w x, max h y)
+    ( \(w, h) e ->
+        let mw = maxX e; mh = maxY e
+         in (max w mw, max h mh)
     )
     (0, 0)
+
+-- | Compute the maximum x coordinate of an element. Iterating over
+-- [0..returned value] covers all elements.
+maxX :: Element -> Int
+maxX = \case
+  HorizontalLine x _ l -> x + l - 1
+  VerticalLine x _ _ -> x
+  Cell x _ _ -> x
+  Start x _ -> x
+
+-- | Compute the maximum y coordinate of an element. Iterating over
+-- [0..returned value] covers all elements.
+maxY :: Element -> Int
+maxY = \case
+  HorizontalLine _ y _ -> y
+  VerticalLine _ y l -> y + l - 1
+  Cell _ y _ -> y
+  Start _ y -> y
 
 symbolToChar :: Symbol -> Char
 symbolToChar = \case

--- a/src/Render.hs
+++ b/src/Render.hs
@@ -39,6 +39,9 @@ elementContains element (cx, cy) =
     Cell x y _ -> (x == cx) && (y == cy)
     Start x y -> (x == cx) && (y == cy)
 
+-- | Compute the width and height of the map. This is the maximum
+-- size of the x and y coordinates of all elements. Iterating over [0..w]
+-- and [0..h] will cover all elements.
 computeWidthAndHeight :: [Element] -> (Int, Int)
 computeWidthAndHeight =
   foldl

--- a/src/Render.hs
+++ b/src/Render.hs
@@ -27,7 +27,8 @@ renderCell elements cell =
       case e of
         Start _ _ -> Just '>'
         Cell _ _ s -> Just $ symbolToChar s
-        _ -> Just '#'
+        HorizontalLine {} -> Just '#'
+        VerticalLine {} -> Just '#'
     go (_ : es) = go es
 
 elementContains :: Element -> (Int, Int) -> Bool

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -4,6 +4,7 @@ module Main where
 
 import Data.Either (isLeft)
 import Lib
+import Render
 import Test.Hspec
 
 -- | Run me with @cabal test min-mega-test@
@@ -46,3 +47,11 @@ main = hspec $ do
       runMyParser parseElements "HLine 0 0 1\n\nVLine 0 0 1" `shouldBe` (Right $ [HorizontalLine 0 0 1, VerticalLine 0 0 1])
 
       runMyParser parseElements "HLine 0 0 1;;VLine 0 0 1" `shouldSatisfy` isLeft
+  describe "render" $ do
+    it "render" $ do
+      computeWidthAndHeight [Cell 0 0 Wall] `shouldBe` (0, 0)
+      computeWidthAndHeight [HorizontalLine 0 0 1] `shouldBe` (0, 0)
+      computeWidthAndHeight [VerticalLine 0 0 3] `shouldBe` (0, 2)
+      computeWidthAndHeight [HorizontalLine 0 0 1, VerticalLine 0 0 1] `shouldBe` (0, 0)
+      computeWidthAndHeight [HorizontalLine 0 0 3] `shouldBe` (2, 0)
+      computeWidthAndHeight [HorizontalLine 0 0 3, VerticalLine 0 0 2] `shouldBe` (2, 1)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -49,9 +49,9 @@ main = hspec $ do
       runMyParser parseElements "HLine 0 0 1;;VLine 0 0 1" `shouldSatisfy` isLeft
   describe "render" $ do
     it "render" $ do
-      computeWidthAndHeight [Cell 0 0 Wall] `shouldBe` (0, 0)
-      computeWidthAndHeight [HorizontalLine 0 0 1] `shouldBe` (0, 0)
-      computeWidthAndHeight [VerticalLine 0 0 3] `shouldBe` (0, 2)
-      computeWidthAndHeight [HorizontalLine 0 0 1, VerticalLine 0 0 1] `shouldBe` (0, 0)
-      computeWidthAndHeight [HorizontalLine 0 0 3] `shouldBe` (2, 0)
-      computeWidthAndHeight [HorizontalLine 0 0 3, VerticalLine 0 0 2] `shouldBe` (2, 1)
+      maxXY [Cell 0 0 Wall] `shouldBe` (0, 0)
+      maxXY [HorizontalLine 0 0 1] `shouldBe` (0, 0)
+      maxXY [VerticalLine 0 0 3] `shouldBe` (0, 2)
+      maxXY [HorizontalLine 0 0 1, VerticalLine 0 0 1] `shouldBe` (0, 0)
+      maxXY [HorizontalLine 0 0 3] `shouldBe` (2, 0)
+      maxXY [HorizontalLine 0 0 3, VerticalLine 0 0 2] `shouldBe` (2, 1)


### PR DESCRIPTION
## Context

Fixes https://github.com/tweag/minimal-megaparsec-tutorial/issues/1

## How to trust this PR

* Look at the new tests
* See that the behavior was not changed (see the golden test added by )https://github.com/tweag/minimal-megaparsec-tutorial/pull/4 being unchanged)

Finally, test the edge cases reported by @panserbjorn:

```
> cabal repl Lib
ghci> Render.render [VerticalLine 0 0 1]
#
ghci> Render.render [HorizontalLine 0 0 1]
#
ghci> Render.render [HorizontalLine 0 0 8, VerticalLine 0 0 8]
########
#       
#       
#       
#       
#       
#       
#       
```